### PR TITLE
Negative names

### DIFF
--- a/Flags.ts
+++ b/Flags.ts
@@ -3,13 +3,6 @@ export type Flags = {
 	[flag: string]: Flags | boolean | undefined
 }
 
-// const permissions = {
-// 	"---o1---": { user: true },
-// }
-// stringify
-// "---o1---.user" ---> "+---o1---.user"
-// { "--o1---": { user: false }} ---> permission
-
 export namespace Flags {
 	export const type: isly.Type<Flags> = isly.record<Flags>(
 		isly.string(),

--- a/Flags.ts
+++ b/Flags.ts
@@ -3,6 +3,13 @@ export type Flags = {
 	[flag: string]: Flags | boolean | undefined
 }
 
+// const permissions = {
+// 	"---o1---": { user: true },
+// }
+// stringify
+// "---o1---.user" ---> "+---o1---.user"
+// { "--o1---": { user: false }} ---> permission
+
 export namespace Flags {
 	export const type: isly.Type<Flags> = isly.record<Flags>(
 		isly.string(),
@@ -17,7 +24,7 @@ export namespace Flags {
 
 	export function stringify(value: Flags): string {
 		return Object.entries(getBaseKey(value))
-			.reduce<string>((r, c) => r + (c[1] ? "" : "-") + c[0] + " ", "")
+			.reduce<string>((r, [name, value]) => r + (!value ? "-" : name.startsWith("-") ? "+" : "") + name + " ", "")
 			.trim()
 	}
 }

--- a/index.spec.ts
+++ b/index.spec.ts
@@ -6,6 +6,11 @@ describe("flagly", () => {
 		const flags = flagly.parse(testString)
 		expect(flagly.Flags.stringify(flags)).toEqual(testString)
 	})
+	it("stringify negative name", () => {
+		const minusName = { "-test": { user: true, org: false } }
+		expect(flagly.parse(flagly.Flags.stringify(minusName))).toEqual(minusName)
+	})
+
 	it("get.path", () => {
 		const flags: flagly.Flags = { user: { view: true, write: true } }
 		expect(flagly.get.path(flags, "user.view")).toEqual(true)

--- a/parse.ts
+++ b/parse.ts
@@ -14,7 +14,7 @@ function tokenize(flags: string): [boolean, string[]][] {
 			let state: boolean | undefined =
 				!flag.startsWith("-") && !flag.startsWith("!") && (flag.startsWith("+") || undefined)
 			if (state != undefined)
-				flag = flag.substr(1)
+				flag = flag.substring(1)
 			else
 				state = true
 			return [state, flag.split(".")]


### PR DESCRIPTION
If the identifier in the flags object started with `-` the process of stringification -> parsing caused the identifiers name to be parsed as the flag was falsy causing renaming of the flag and the opposite value it was supposed to have. 

This change adds `+` in front of identifiers starting with `-` to prevent this from happening