### PR TITLE
Reduce priority

### DIFF
--- a/reduce.spec.ts
+++ b/reduce.spec.ts
@@ -33,10 +33,10 @@ describe("flagly.reduce", () => {
 		const flags = flagly.reduce({ a: { b: { c: true } } }, { a: { b: false } })
 		expect(flags).toEqual({ a: { b: false } })
 	})
-	it("true > object", () => {
+	it("right side true > object", () => {
 		expect(flagly.reduce({ a: { b: true } }, { a: true })).toEqual({ a: true })
 	})
-	it("object > false", () => {
-		expect(flagly.reduce({ a: { b: false } }, { a: { b: { c: true } } })).toEqual({ a: { b: { c: true } } })
+	it("right side object > true", () => {
+		expect(flagly.reduce({ a: true }, { a: { b: true } })).toEqual({ a: { b: true } })
 	})
 })

--- a/reduce.spec.ts
+++ b/reduce.spec.ts
@@ -33,4 +33,10 @@ describe("flagly.reduce", () => {
 		const flags = flagly.reduce({ a: { b: { c: true } } }, { a: { b: false } })
 		expect(flags).toEqual({ a: { b: false } })
 	})
+	it("true > object", () => {
+		expect(flagly.reduce({ a: { b: true } }, { a: true })).toEqual({ a: true })
+	})
+	it("object > false", () => {
+		expect(flagly.reduce({ a: { b: false } }, { a: { b: { c: true } } })).toEqual({ a: { b: { c: true } } })
+	})
 })

--- a/reduce.ts
+++ b/reduce.ts
@@ -14,7 +14,6 @@ export function reduce(...flags: Flags[]): Flags {
 							: typeof value != "object"
 							? value && old
 							: reduce(old, value),
-					// [flag]: typeof old != "object" ? value : typeof value != "object" ? value && old : reduce(old, value),
 				}
 			}, result),
 		{}

--- a/reduce.ts
+++ b/reduce.ts
@@ -1,14 +1,22 @@
 import { Flags } from "./Flags"
 export function reduce(...flags: Flags[]): Flags {
 	return flags.reduce<Flags>(
-		(r, f) =>
-			Object.entries(f).reduce((result, [flag, value]) => {
+		(result, flag) =>
+			Object.entries(flag).reduce((result, [flag, value]) => {
 				const old = result[flag]
 				return {
 					...result,
-					[flag]: typeof old != "object" ? value : typeof value != "object" ? value && old : reduce(old, value),
+					[flag]:
+						value == true
+							? true
+							: typeof old != "object"
+							? value ?? old
+							: typeof value != "object"
+							? value && old
+							: reduce(old, value),
+					// [flag]: typeof old != "object" ? value : typeof value != "object" ? value && old : reduce(old, value),
 				}
-			}, r),
+			}, result),
 		{}
 	)
 }


### PR DESCRIPTION
Prefer right side `true` over left side object. 

`true` should mean everything in the object. If right side is `true` it should have higher priority than the left side object.