### PR TITLE
nested get

### DIFF
--- a/get.spec.ts
+++ b/get.spec.ts
@@ -6,5 +6,9 @@ describe("flagly.get", () => {
 	it("not set", () => expect(flagly.get({}, "simple")).toEqual(undefined))
 	it("false", () => expect(flagly.get({ simple: false }, "simple")).toEqual(false))
 	it("undefined", () => expect(flagly.get(undefined, "simple")).toEqual(undefined))
-	it("nested", () => expect(flagly.get({ a: true }, "a", "b")).toEqual(true))
+	it("nested", () => {
+		expect(flagly.get({ a: true }, "a", "b")).toEqual(true)
+		expect(flagly.get({ a: true, b: { c: true } }, "b", "d")).toEqual(undefined)
+		expect(flagly.get({ a: true, b: { c: true } }, "b", "c", "d")).toEqual(true)
+	})
 })

--- a/get.spec.ts
+++ b/get.spec.ts
@@ -6,4 +6,5 @@ describe("flagly.get", () => {
 	it("not set", () => expect(flagly.get({}, "simple")).toEqual(undefined))
 	it("false", () => expect(flagly.get({ simple: false }, "simple")).toEqual(false))
 	it("undefined", () => expect(flagly.get(undefined, "simple")).toEqual(undefined))
+	it("nested", () => expect(flagly.get({ a: true }, "a", "b")).toEqual(true))
 })

--- a/get.ts
+++ b/get.ts
@@ -4,7 +4,13 @@ export const get = Object.assign(getFlags, { path: getPaths })
 function getFlags(flags?: Readonly<Flags>, ...flag: string[]): Flags | boolean | undefined {
 	const key = flag.at(0)
 	const next = key == undefined ? undefined : flags?.[key]
-	return flag.length == 1 ? next : typeof next == "object" ? get(next, ...flag.slice(1)) : undefined
+	return next == true
+		? true
+		: flag.length == 1
+		? next
+		: typeof next == "object"
+		? get(next, ...flag.slice(1))
+		: undefined
 }
 function getPaths(flags: Readonly<Flags>, ...paths: string[]): boolean {
 	return !!paths.every(path => get(flags, ...path.split(".")) == true)


### PR DESCRIPTION
given the following flagly object 
```ts
flagly = {
  a : true,
}
```
when `flagly.get` runs on that object with the flags `["a", "b", "c"]` the result should be expected to be `true`since a is `a: true` should mean that `a` and everything beneath `a` is `true`. 